### PR TITLE
Switch Lambda runtime from go1.x to provided.al2023

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jaymccon @troy-ameigh @gargana @aws-ia-ci @aws-ia/aws-ia
+* @troy-ameigh @aws-ia-ci

--- a/functions/source/EksClusterResource/.rpdk-config
+++ b/functions/source/EksClusterResource/.rpdk-config
@@ -1,9 +1,9 @@
 {
     "typeName": "AWSQS::EKS::Cluster",
     "language": "go",
-    "runtime": "go1.x",
-    "entrypoint": "handler",
-    "testEntrypoint": "handler",
+    "runtime": "provided.al2023",
+    "entrypoint": "bootstrap",
+    "testEntrypoint": "bootstrap",
     "settings": {
         "importpath": "github.com/aws-quickstart/quickstart-amazon-eks-cluster-resource-provider",
         "import_path": "github.com/aws-quickstart/quickstart-amazon-eks-cluster-resource-provider",

--- a/functions/source/EksClusterResource/Makefile
+++ b/functions/source/EksClusterResource/Makefile
@@ -14,8 +14,8 @@ SUM_FILES ?= $(TYPE_NAME_LOWER).json go.mod cmd/* vpc/* cmd/resource/*
 build:
 	go mod tidy
 	cfn generate
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc,logging" -o bin/bootstrap2 cmd/main.go
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc" -o bin/bootstrap vpc/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="logging" -o bin/bootstrap2 cmd/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/bootstrap vpc/main.go
 
 package: build
 	find . -exec touch -t 202007010000.00 {} +

--- a/functions/source/EksClusterResource/Makefile
+++ b/functions/source/EksClusterResource/Makefile
@@ -14,16 +14,16 @@ SUM_FILES ?= $(TYPE_NAME_LOWER).json go.mod cmd/* vpc/* cmd/resource/*
 build:
 	go mod tidy
 	cfn generate
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc,logging" -o bin/bootstrap cmd/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc,logging" -o bin/bootstrap2 cmd/main.go
 	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc" -o bin/bootstrap vpc/main.go
 
 package: build
 	find . -exec touch -t 202007010000.00 {} +
-	cd bin ; zip -FS -X bootstrap.zip bootstrap ; rm bootstrap ; zip -X ../bootstrap.zip ./bootstrap.zip ./bootstrap ; cd ..
+	cd bin ; zip -FS -X k8svpc.zip bootstrap ; rm bootstrap ; mv bootstrap2 bootstrap ; zip -X ../handler.zip ./k8svpc.zip ./bootstrap ; cd ..
 	cp  awsqs-eks-cluster.json schema.json
 	find . -exec touch -t 202007010000.00 {} +
-	zip -Xr awsqs-eks-cluster.zip ./bootstrap.zip ./schema.json ./.rpdk-config ./inputs
-	rm ./bootstrap.zip ./schema.json
+	zip -Xr awsqs-eks-cluster.zip ./handler.zip ./schema.json ./.rpdk-config ./inputs
+	rm ./handler.zip ./schema.json
 	aws s3 cp ./awsqs-eks-cluster.zip s3://$(BUCKET)/
 
 register:

--- a/functions/source/EksClusterResource/Makefile
+++ b/functions/source/EksClusterResource/Makefile
@@ -14,16 +14,16 @@ SUM_FILES ?= $(TYPE_NAME_LOWER).json go.mod cmd/* vpc/* cmd/resource/*
 build:
 	go mod tidy
 	cfn generate
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="logging" -o bin/handler cmd/main.go
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/k8svpc vpc/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc,logging" -o bin/bootstrap cmd/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc" -o bin/bootstrap vpc/main.go
 
 package: build
 	find . -exec touch -t 202007010000.00 {} +
-	cd bin ; zip -FS -X k8svpc.zip k8svpc ; rm k8svpc ; zip -X ../handler.zip ./k8svpc.zip ./handler ; cd ..
+	cd bin ; zip -FS -X bootstrap.zip bootstrap ; rm bootstrap ; zip -X ../bootstrap.zip ./bootstrap.zip ./bootstrap ; cd ..
 	cp  awsqs-eks-cluster.json schema.json
 	find . -exec touch -t 202007010000.00 {} +
-	zip -Xr awsqs-eks-cluster.zip ./handler.zip ./schema.json ./.rpdk-config ./inputs
-	rm ./handler.zip ./schema.json
+	zip -Xr awsqs-eks-cluster.zip ./bootstrap.zip ./schema.json ./.rpdk-config ./inputs
+	rm ./bootstrap.zip ./schema.json
 	aws s3 cp ./awsqs-eks-cluster.zip s3://$(BUCKET)/
 
 register:

--- a/functions/source/EksClusterResource/Makefile.package
+++ b/functions/source/EksClusterResource/Makefile.package
@@ -3,10 +3,10 @@
 package:
 	go mod tidy
 	cfn generate
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc,logging" -o bin/bootstrap cmd/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc,logging" -o bin/bootstrap2 cmd/main.go
 	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc" -o bin/bootstrap vpc/main.go
 	find . -exec touch -t 202007010000.00 {} +
-	cd bin ; zip -FS -X bootstrap.zip bootstrap ; rm bootstrap ; zip -X ../bootstrap.zip ./bootstrap.zip ./bootstrap ; cd ..
+	cd bin ; zip -FS -X k8svpc.zip bootstrap ; rm bootstrap ; mv bootstrap2 bootstrap ; zip -X ../handler.zip ./k8svpc.zip ./bootstrap ; cd ..
 	cp  awsqs-eks-cluster.json schema.json
 	find . -exec touch -t 202007010000.00 {} +
 	zip -Xr awsqs-eks-cluster.zip ./bootstrap.zip ./schema.json ./.rpdk-config ./inputs

--- a/functions/source/EksClusterResource/Makefile.package
+++ b/functions/source/EksClusterResource/Makefile.package
@@ -3,11 +3,11 @@
 package:
 	go mod tidy
 	cfn generate
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="logging" -o bin/handler cmd/main.go
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/k8svpc vpc/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc,logging" -o bin/bootstrap cmd/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc" -o bin/bootstrap vpc/main.go
 	find . -exec touch -t 202007010000.00 {} +
-	cd bin ; zip -FS -X k8svpc.zip k8svpc ; rm k8svpc ; zip -X ../handler.zip ./k8svpc.zip ./handler ; cd ..
+	cd bin ; zip -FS -X bootstrap.zip bootstrap ; rm bootstrap ; zip -X ../bootstrap.zip ./bootstrap.zip ./bootstrap ; cd ..
 	cp  awsqs-eks-cluster.json schema.json
 	find . -exec touch -t 202007010000.00 {} +
-	zip -Xr awsqs-eks-cluster.zip ./handler.zip ./schema.json ./.rpdk-config ./inputs
-	rm ./handler.zip ./schema.json
+	zip -Xr awsqs-eks-cluster.zip ./bootstrap.zip ./schema.json ./.rpdk-config ./inputs
+	rm ./bootstrap.zip ./schema.json

--- a/functions/source/EksClusterResource/Makefile.package
+++ b/functions/source/EksClusterResource/Makefile.package
@@ -3,8 +3,8 @@
 package:
 	go mod tidy
 	cfn generate
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc,logging" -o bin/bootstrap2 cmd/main.go
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc" -o bin/bootstrap vpc/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="logging" -o bin/bootstrap2 cmd/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/bootstrap vpc/main.go
 	find . -exec touch -t 202007010000.00 {} +
 	cd bin ; zip -FS -X k8svpc.zip bootstrap ; rm bootstrap ; mv bootstrap2 bootstrap ; zip -X ../handler.zip ./k8svpc.zip ./bootstrap ; cd ..
 	cp  awsqs-eks-cluster.json schema.json

--- a/functions/source/EksClusterResource/cmd/resource/lambda.go
+++ b/functions/source/EksClusterResource/cmd/resource/lambda.go
@@ -18,11 +18,11 @@ import (
 )
 
 const (
-	ZipFile            string = "k8svpc.zip"
+	ZipFile            string = "bootstrap.zip"
 	FunctionNamePrefix string = "k8s-api-vpc-connector-"
-	Handler            string = "k8svpc"
+	Handler            string = "bootstrap"
 	MemorySize         int64  = 256
-	Runtime            string = "go1.x"
+	Runtime            string = "provided.al2023"
 	Timeout            int64  = 900
 )
 

--- a/functions/source/EksClusterResource/cmd/resource/lambda.go
+++ b/functions/source/EksClusterResource/cmd/resource/lambda.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	ZipFile            string = "bootstrap.zip"
+	ZipFile            string = "k8svpc.zip"
 	FunctionNamePrefix string = "k8s-api-vpc-connector-"
 	Handler            string = "bootstrap"
 	MemorySize         int64  = 256

--- a/functions/source/HelmReleaseResource/.rpdk-config
+++ b/functions/source/HelmReleaseResource/.rpdk-config
@@ -2,9 +2,9 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWSQS::Kubernetes::Helm",
     "language": "go",
-    "runtime": "go1.x",
-    "entrypoint": "handler",
-    "testEntrypoint": "handler",
+    "runtime": "provided.al2023",
+    "entrypoint": "bootstrap",
+    "testEntrypoint": "bootstrap",
     "settings": {
         "importpath": "github.com/aws-quickstart/quickstart-helm-resource-provider",
         "import_path": "github.com/aws-quickstart/quickstart-helm-resource-provider",

--- a/functions/source/HelmReleaseResource/Makefile
+++ b/functions/source/HelmReleaseResource/Makefile
@@ -10,12 +10,12 @@ LOG_ROLE ?= use-existing
 build:
 	go mod tidy -v
 	cfn generate
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc,logging" -o bin/bootstrap cmd/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc,logging" -o bin/bootstrap2 cmd/main.go
 	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc" -o bin/bootstrap vpc/main.go
 
 package: build
 	find . -exec touch -t 202007010000.00 {} +
-	cd bin ; zip -FS -X bootstrap.zip bootstrap ; rm bootstrap ; zip -X ../bootstrap.zip ./bootstrap.zip ./bootstrap ; cd ..
+	cd bin ; zip -FS -X k8svpc.zip bootstrap ; rm bootstrap ; mv bootstrap2 bootstrap ; zip -X ../handler.zip ./k8svpc.zip ./bootstrap ; cd ..
 	cp  $(TYPE_NAME_LOWER).json schema.json
 	find . -exec touch -t 202007010000.00 {} +
 	zip -Xr $(TYPE_NAME_LOWER).zip ./bootstrap.zip ./schema.json ./.rpdk-config ./inputs

--- a/functions/source/HelmReleaseResource/Makefile
+++ b/functions/source/HelmReleaseResource/Makefile
@@ -19,7 +19,7 @@ package: build
 	cp  $(TYPE_NAME_LOWER).json schema.json
 	find . -exec touch -t 202007010000.00 {} +
 	zip -Xr $(TYPE_NAME_LOWER).zip ./handler.zip ./schema.json ./.rpdk-config ./inputs
-	rm ./hanlder.zip ./schema.json
+	rm ./handler.zip ./schema.json
 	aws s3 cp ./$(TYPE_NAME_LOWER).zip s3://$(BUCKET)/
 
 register:

--- a/functions/source/HelmReleaseResource/Makefile
+++ b/functions/source/HelmReleaseResource/Makefile
@@ -10,8 +10,8 @@ LOG_ROLE ?= use-existing
 build:
 	go mod tidy -v
 	cfn generate
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc,logging" -o bin/bootstrap2 cmd/main.go
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc" -o bin/bootstrap vpc/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="logging" -o bin/bootstrap2 cmd/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/bootstrap vpc/main.go
 
 package: build
 	find . -exec touch -t 202007010000.00 {} +

--- a/functions/source/HelmReleaseResource/Makefile
+++ b/functions/source/HelmReleaseResource/Makefile
@@ -10,16 +10,16 @@ LOG_ROLE ?= use-existing
 build:
 	go mod tidy -v
 	cfn generate
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="logging" -o bin/handler cmd/main.go
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/k8svpc vpc/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc,logging" -o bin/bootstrap cmd/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc" -o bin/bootstrap vpc/main.go
 
 package: build
 	find . -exec touch -t 202007010000.00 {} +
-	cd bin ; zip -FS -X k8svpc.zip k8svpc ; rm k8svpc ; zip -X ../handler.zip ./k8svpc.zip ./handler ; cd ..
+	cd bin ; zip -FS -X bootstrap.zip bootstrap ; rm bootstrap ; zip -X ../bootstrap.zip ./bootstrap.zip ./bootstrap ; cd ..
 	cp  $(TYPE_NAME_LOWER).json schema.json
 	find . -exec touch -t 202007010000.00 {} +
-	zip -Xr $(TYPE_NAME_LOWER).zip ./handler.zip ./schema.json ./.rpdk-config ./inputs
-	rm ./handler.zip ./schema.json
+	zip -Xr $(TYPE_NAME_LOWER).zip ./bootstrap.zip ./schema.json ./.rpdk-config ./inputs
+	rm ./bootstrap.zip ./schema.json
 	aws s3 cp ./$(TYPE_NAME_LOWER).zip s3://$(BUCKET)/
 
 register:
@@ -35,7 +35,7 @@ register:
 	TOKEN=`aws cloudformation register-type \
 		--type "RESOURCE" \
 		--type-name  "$(TYPE_NAME)" \
-		--schema-handler-package s3://$(BUCKET)/$(TYPE_NAME_LOWER).zip \
+		--schema-bootstrap-package s3://$(BUCKET)/$(TYPE_NAME_LOWER).zip \
 		--logging-config LogRoleArn=$${R_LOG_ROLE},LogGroupName=/cloudformation/registry/$(TYPE_NAME_LOWER) \
 		--execution-role-arn $${R_EX_ROLE} \
 		--region $(REGION) \

--- a/functions/source/HelmReleaseResource/Makefile
+++ b/functions/source/HelmReleaseResource/Makefile
@@ -18,8 +18,8 @@ package: build
 	cd bin ; zip -FS -X k8svpc.zip bootstrap ; rm bootstrap ; mv bootstrap2 bootstrap ; zip -X ../handler.zip ./k8svpc.zip ./bootstrap ; cd ..
 	cp  $(TYPE_NAME_LOWER).json schema.json
 	find . -exec touch -t 202007010000.00 {} +
-	zip -Xr $(TYPE_NAME_LOWER).zip ./bootstrap.zip ./schema.json ./.rpdk-config ./inputs
-	rm ./bootstrap.zip ./schema.json
+	zip -Xr $(TYPE_NAME_LOWER).zip ./handler.zip ./schema.json ./.rpdk-config ./inputs
+	rm ./hanlder.zip ./schema.json
 	aws s3 cp ./$(TYPE_NAME_LOWER).zip s3://$(BUCKET)/
 
 register:
@@ -35,7 +35,7 @@ register:
 	TOKEN=`aws cloudformation register-type \
 		--type "RESOURCE" \
 		--type-name  "$(TYPE_NAME)" \
-		--schema-bootstrap-package s3://$(BUCKET)/$(TYPE_NAME_LOWER).zip \
+		--schema-handler-package s3://$(BUCKET)/$(TYPE_NAME_LOWER).zip \
 		--logging-config LogRoleArn=$${R_LOG_ROLE},LogGroupName=/cloudformation/registry/$(TYPE_NAME_LOWER) \
 		--execution-role-arn $${R_EX_ROLE} \
 		--region $(REGION) \

--- a/functions/source/HelmReleaseResource/Makefile.package
+++ b/functions/source/HelmReleaseResource/Makefile.package
@@ -3,8 +3,8 @@
 package:
 	go mod tidy
 	cfn generate
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc,logging" -o bin/bootstrap2 cmd/main.go
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc" -o bin/bootstrap vpc/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="logging" -o bin/bootstrap2 cmd/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/bootstrap vpc/main.go
 	find . -exec touch -t 202007010000.00 {} +
 	cd bin ; zip -FS -X k8svpc.zip bootstrap ; rm bootstrap ; mv bootstrap2 bootstrap ; zip -X ../handler.zip ./k8svpc.zip ./bootstrap ; cd ..
 	cp  awsqs-kubernetes-helm.json schema.json

--- a/functions/source/HelmReleaseResource/Makefile.package
+++ b/functions/source/HelmReleaseResource/Makefile.package
@@ -3,11 +3,11 @@
 package:
 	go mod tidy
 	cfn generate
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="logging" -o bin/handler cmd/main.go
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/k8svpc vpc/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc,logging" -o bin/bootstrap cmd/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc" -o bin/bootstrap vpc/main.go
 	find . -exec touch -t 202007010000.00 {} +
-	cd bin ; zip -FS -X k8svpc.zip k8svpc ; rm k8svpc ; zip -X ../handler.zip ./k8svpc.zip ./handler ; cd ..
+	cd bin ; zip -FS -X bootstrap.zip bootstrap ; rm bootstrap ; zip -X ../bootstrap.zip ./bootstrap.zip ./bootstrap ; cd ..
 	cp  awsqs-kubernetes-helm.json schema.json
 	find . -exec touch -t 202007010000.00 {} +
-	zip -Xr awsqs-kubernetes-helm.zip ./handler.zip ./schema.json ./.rpdk-config ./inputs/
-	rm ./handler.zip ./schema.json
+	zip -Xr awsqs-kubernetes-helm.zip ./bootstrap.zip ./schema.json ./.rpdk-config ./inputs/
+	rm ./bootstrap.zip ./schema.json

--- a/functions/source/HelmReleaseResource/Makefile.package
+++ b/functions/source/HelmReleaseResource/Makefile.package
@@ -3,11 +3,11 @@
 package:
 	go mod tidy
 	cfn generate
-	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc,logging" -o bin/bootstrap cmd/main.go
+	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc,logging" -o bin/bootstrap2 cmd/main.go
 	env CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="lambda.norpc" -o bin/bootstrap vpc/main.go
 	find . -exec touch -t 202007010000.00 {} +
-	cd bin ; zip -FS -X bootstrap.zip bootstrap ; rm bootstrap ; zip -X ../bootstrap.zip ./bootstrap.zip ./bootstrap ; cd ..
+	cd bin ; zip -FS -X k8svpc.zip bootstrap ; rm bootstrap ; mv bootstrap2 bootstrap ; zip -X ../handler.zip ./k8svpc.zip ./bootstrap ; cd ..
 	cp  awsqs-kubernetes-helm.json schema.json
 	find . -exec touch -t 202007010000.00 {} +
-	zip -Xr awsqs-kubernetes-helm.zip ./bootstrap.zip ./schema.json ./.rpdk-config ./inputs/
-	rm ./bootstrap.zip ./schema.json
+	zip -Xr awsqs-kubernetes-helm.zip ./handler.zip ./schema.json ./.rpdk-config ./inputs/
+	rm ./handler.zip ./schema.json

--- a/functions/source/HelmReleaseResource/cmd/resource/lambda.go
+++ b/functions/source/HelmReleaseResource/cmd/resource/lambda.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	ZipFile            string = "bootstrap.zip"
+	ZipFile            string = "k8svpc.zip"
 	FunctionNamePrefix string = "helm-provider-vpc-connector-"
 	Handler            string = "bootstrap"
 	MemorySize         int64  = 384

--- a/functions/source/HelmReleaseResource/cmd/resource/lambda.go
+++ b/functions/source/HelmReleaseResource/cmd/resource/lambda.go
@@ -18,11 +18,11 @@ import (
 )
 
 const (
-	ZipFile            string = "k8svpc.zip"
+	ZipFile            string = "bootstrap.zip"
 	FunctionNamePrefix string = "helm-provider-vpc-connector-"
-	Handler            string = "k8svpc"
+	Handler            string = "bootstrap"
 	MemorySize         int64  = 384
-	Runtime            string = "go1.x"
+	Runtime            string = "provided.al2023"
 	Timeout            int64  = 900
 	UpdateInProgress   string = "The function could not be updated due to a concurrent update operation."
 	LambdaMaxSubnets   int    = 16

--- a/functions/source/HelmReleaseResource/cmd/resource/lambda_test.go
+++ b/functions/source/HelmReleaseResource/cmd/resource/lambda_test.go
@@ -356,7 +356,7 @@ func TestNewLambdaResource(t *testing.T) {
 				nameSuffix:   aws.String("37b6fa0c59ff93e123871e92573b290c"),
 				vpcConfig:    v,
 				functionName: aws.String("helm-provider-vpc-connector-37b6fa0c59ff93e123871e92573b290c"),
-				functionFile: "bootstrap.zip",
+				functionFile: "k8svpc.zip",
 			},
 		},
 		"WithKubeConfig": {

--- a/functions/source/HelmReleaseResource/cmd/resource/lambda_test.go
+++ b/functions/source/HelmReleaseResource/cmd/resource/lambda_test.go
@@ -367,7 +367,7 @@ func TestNewLambdaResource(t *testing.T) {
 				nameSuffix:   aws.String("88c81d0fbff37a9cfae847245f69cde9"),
 				vpcConfig:    v,
 				functionName: aws.String("helm-provider-vpc-connector-88c81d0fbff37a9cfae847245f69cde9"),
-				functionFile: "bootstrap.zip",
+				functionFile: "k8svpc.zip",
 			},
 		},
 	}

--- a/functions/source/HelmReleaseResource/cmd/resource/lambda_test.go
+++ b/functions/source/HelmReleaseResource/cmd/resource/lambda_test.go
@@ -356,7 +356,7 @@ func TestNewLambdaResource(t *testing.T) {
 				nameSuffix:   aws.String("37b6fa0c59ff93e123871e92573b290c"),
 				vpcConfig:    v,
 				functionName: aws.String("helm-provider-vpc-connector-37b6fa0c59ff93e123871e92573b290c"),
-				functionFile: "k8svpc.zip",
+				functionFile: "bootstrap.zip",
 			},
 		},
 		"WithKubeConfig": {
@@ -367,7 +367,7 @@ func TestNewLambdaResource(t *testing.T) {
 				nameSuffix:   aws.String("88c81d0fbff37a9cfae847245f69cde9"),
 				vpcConfig:    v,
 				functionName: aws.String("helm-provider-vpc-connector-88c81d0fbff37a9cfae847245f69cde9"),
-				functionFile: "k8svpc.zip",
+				functionFile: "bootstrap.zip",
 			},
 		},
 	}

--- a/functions/source/HelmReleaseResource/template.yml
+++ b/functions/source/HelmReleaseResource/template.yml
@@ -10,17 +10,17 @@ Resources:
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Handler: handler
-      Runtime: go1.x
+      Handler: bootstrap
+      Runtime: provided.al2023
       CodeUri: bin/
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
-      Handler: handler
-      Runtime: go1.x
+      Handler: bootstrap
+      Runtime: provided.al2023
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
 

--- a/templates/amazon-eks-per-region-resources.template.yaml
+++ b/templates/amazon-eks-per-region-resources.template.yaml
@@ -307,7 +307,7 @@ Resources:
     Properties:
       ServiceToken: !GetAtt RegisterTypeFunction.Arn
       TypeName: AWSQS::Kubernetes::Helm
-      Version: 3.1.2
+      Version: 3.3.0
       RandomStr: !Ref RandomStr
       SchemaHandlerPackage: !Sub s3://eks-quickstart-lambdazips-${AWS::Region}-${AWS::AccountId}/${QSS3KeyPrefix}functions/packages/HelmReleaseResource/awsqs-kubernetes-helm.zip
       IamPolicy:
@@ -357,7 +357,7 @@ Resources:
     Properties:
       ServiceToken: !GetAtt RegisterTypeFunction.Arn
       TypeName: AWSQS::Kubernetes::Get
-      Version: 3.2.3
+      Version: 3.3.0
       RandomStr: !Ref RandomStr
       SchemaHandlerPackage: !Sub s3://eks-quickstart-lambdazips-${AWS::Region}-${AWS::AccountId}/${QSS3KeyPrefix}functions/packages/kubernetesResources/awsqs_kubernetes_get.zip
       IamPolicy:


### PR DESCRIPTION
* Fixes #20 
* https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/